### PR TITLE
Removal of master and slave jargon

### DIFF
--- a/app/mapping/forms.py
+++ b/app/mapping/forms.py
@@ -28,16 +28,16 @@ def makeNewMappingForm(obj, num_map_labelN_lists):
         description = TextAreaField(_l('Mapping description (optional)'))
         m_type = RadioField(_l('Type of mapping'),
             description=_l('An "Automatic" mapping will run each time any card ' \
-                'on the master board is modified, while a "Manual" mapping ' \
+                'on the main board is modified, while a "Manual" mapping ' \
                 'will need to be run each time from the home page.'),
             choices=[("automatic", "Automatic"), ("manual", "Manual")],
             default='automatic',
             validators=[DataRequired()])
-        master_board = SelectField(_l('Master board'), coerce=str)
+        main_board = SelectField(_l('Main board'), coerce=str)
         labels = MultiCheckboxField(_l('Which labels need mapping?'), \
             coerce=str, render_kw={'style':'height: auto; list-style: none;'})
 
-        def validate_master_board(form, field):
+        def validate_main_board(form, field):
             if not form.labels.choices:
                 raise ValidationError(_l('None of the labels on this board have '
                     'names. Only named labels can be selected for mapping.'))
@@ -59,7 +59,7 @@ class DeleteMappingForm(FlaskForm):
 
 
 class RunMappingForm(FlaskForm):
-    submit_board = SubmitField(_l('Process the entire master board'))
+    submit_board = SubmitField(_l('Process the entire main board'))
     lists = SelectField(_l('List'), coerce=str,
         validators=[Regexp("^[0-9a-fA-F]{24}$",
         message=_l('Invalid Trello list ID format, it must be a 24 character string.'))])

--- a/app/mapping/routes.py
+++ b/app/mapping/routes.py
@@ -79,15 +79,15 @@ def new_or_edit(mapping_id=None):
     step = 1
     selected_labels = []
     if request.method == 'POST' or mapping_id:
-        use_default_master_board = False
-        form.master_board.choices = [(b["id"], b["name"]) for b in boards]
-        # TODO (#74): show error message if form.master_board.choices is empty
-        if not form.master_board.data:
-            use_default_master_board = True
-            form.master_board.data = form.master_board.choices[0][0]
+        use_default_main_board = False
+        form.main_board.choices = [(b["id"], b["name"]) for b in boards]
+        # TODO (#74): show error message if form.main_board.choices is empty
+        if not form.main_board.data:
+            use_default_main_board = True
+            form.main_board.data = form.main_board.choices[0][0]
         labels_names = {}
         labels = perform_request("GET", "boards/%s/labels" % \
-            form.master_board.data,
+            form.main_board.data,
             key=current_app.config['TRELLO_API_KEY'],
             token=current_user.trello_token)
         form.labels.choices = [(l["id"], l["name"]) for l in labels if l["name"]]
@@ -105,8 +105,8 @@ def new_or_edit(mapping_id=None):
             step = 2
         # If the first step cleared, go on to check elements from the second step
         if step == 2:
-            if not use_default_master_board and \
-                re.match("^[0-9a-fA-F]{24}$", form.master_board.data):
+            if not use_default_main_board and \
+                re.match("^[0-9a-fA-F]{24}$", form.main_board.data):
                 # Go to next step
                 step = 3
         # If the second step cleared, go on to check elements from the third step
@@ -147,7 +147,7 @@ def new_or_edit(mapping_id=None):
                 mapping.name = form.name.data
                 mapping.description=form.description.data
                 mapping.m_type=form.m_type.data
-                mapping.master_board=form.master_board.data
+                mapping.main_board=form.main_board.data
                 mapping.destination_lists = json.dumps(destination_lists)
                 mapping.user_id = current_user.id
                 flash(_('Your mapping "%(name)s" has been updated.', name=mapping.name))
@@ -156,7 +156,7 @@ def new_or_edit(mapping_id=None):
                     name=form.name.data,
                     description=form.description.data,
                     m_type=form.m_type.data,
-                    master_board=form.master_board.data,
+                    main_board=form.main_board.data,
                     destination_lists = json.dumps(destination_lists),
                     user_id = current_user.id)
                 current_user.mappings.append(mapping)
@@ -191,7 +191,7 @@ def new_or_edit(mapping_id=None):
 
     # Remove fields from later steps
     if step < 2:
-        del form.master_board
+        del form.main_board
     if step < 3:
         del form.labels
     if step < 4:
@@ -266,7 +266,7 @@ def run(mapping_id):
         return redirect(url_for('mapping.run', mapping_id=mapping_id))
 
     rmf = RunMappingForm()
-    lists = perform_request("GET", "boards/%s/lists" % mapping.master_board,
+    lists = perform_request("GET", "boards/%s/lists" % mapping.main_board,
         key=current_app.config['TRELLO_API_KEY'],
         token=current_user.trello_token)
     rmf.lists.choices = [(l["id"], l["name"]) for l in lists]
@@ -289,8 +289,8 @@ def run(mapping_id):
         rmf.validate_on_submit()
         if rmf.submit_board.data:
             current_user.launch_task('run_mapping',
-                (mapping.id, "board", mapping.master_board),
-                _('Processing the full "%(mapping_name)s" master board...',
+                (mapping.id, "board", mapping.main_board),
+                _('Processing the full "%(mapping_name)s" main board...',
                     mapping_name=mapping.name))
         if rmf.submit_list.data and rmf.lists.validate(rmf):
             current_user.launch_task('run_mapping',

--- a/app/models.py
+++ b/app/models.py
@@ -158,7 +158,7 @@ class Mapping(db.Model):
     name = db.Column(db.String(128), index=True)
     description = db.Column(db.String(128))
     m_type = db.Column(db.Enum("automatic", "manual", name="mappingtypes"))
-    master_board = db.Column(db.String(128))
+    main_board = db.Column(db.String(128))
     destination_lists = db.Column(db.Text())
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
 

--- a/migrations/versions/9d787c01a5cd_add_mapping_table.py
+++ b/migrations/versions/9d787c01a5cd_add_mapping_table.py
@@ -22,7 +22,7 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('name', sa.String(length=128), nullable=True),
     sa.Column('description', sa.String(length=128), nullable=True),
-    sa.Column('master_board', sa.String(length=128), nullable=True),
+    sa.Column('main_board', sa.String(length=128), nullable=True),
     sa.Column('destination_lists', sa.Text(), nullable=True),
     sa.Column('user_id', sa.Integer(), nullable=True),
     sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,7 +134,7 @@ Exiting...
            ID             |  Name
 mmmmmmmmmmmmmmmmmmmmmmmm  |  Board One
 cccccccccccccccccccccccc  |  Board Two
-Enter your master board ID ('q' to quit):\u0020
+Enter your main board ID ('q' to quit):\u0020
 Exiting...
 """
         expected_exception_code = 37
@@ -151,8 +151,8 @@ Exiting...
            ID             |  Name
 mmmmmmmmmmmmmmmmmmmmmmmm  |  Board One
 cccccccccccccccccccccccc  |  Board Two
-Enter your master board ID ('q' to quit):\u0020
-Invalid board ID, must be 24 characters. Enter your master board ID ('q' to quit):\u0020
+Enter your main board ID ('q' to quit):\u0020
+Invalid board ID, must be 24 characters. Enter your main board ID ('q' to quit):\u0020
 Exiting...
 """
         expected_exception_code = 37
@@ -169,8 +169,8 @@ Exiting...
            ID             |  Name
 mmmmmmmmmmmmmmmmmmmmmmmm  |  Board One
 cccccccccccccccccccccccc  |  Board Two
-Enter your master board ID ('q' to quit):\u0020
-This is not the ID of one of the boards you have access to. Enter your master board ID ('q' to quit):\u0020
+Enter your main board ID ('q' to quit):\u0020
+This is not the ID of one of the boards you have access to. Enter your main board ID ('q' to quit):\u0020
 Exiting...
 """
         expected_exception_code = 37
@@ -187,7 +187,7 @@ Exiting...
            ID             |  Name
 mmmmmmmmmmmmmmmmmmmmmmmm  |  Board One
 cccccccccccccccccccccccc  |  Board Two
-Enter your master board ID ('q' to quit):\u0020
+Enter your main board ID ('q' to quit):\u0020
 Enter a name for this new configuration ('q' to quit):\u0020
 Exiting...
 """
@@ -475,7 +475,7 @@ New configuration saved to file 'data/config_config-name.json'
         self.assertEqual(target.config["name"], vals[3])
         self.assertEqual(target.config["key"], vals[0])
         self.assertEqual(target.config["token"], vals[1])
-        self.assertEqual(target.config["master_board"], vals[2])
+        self.assertEqual(target.config["main_board"], vals[2])
         self.assertEqual(len(target.config["destination_lists"]), 2)
         self.assertEqual(len(target.config["destination_lists"]["Label One"]), 1)
         self.assertEqual(target.config["destination_lists"]["Label One"][0], vals[5])
@@ -502,7 +502,7 @@ New configuration saved to file 'data/config_config-name.json'
         self.assertEqual(target.config["name"], vals[3])
         self.assertEqual(target.config["key"], vals[0])
         self.assertEqual(target.config["token"], vals[1])
-        self.assertEqual(target.config["master_board"], vals[2])
+        self.assertEqual(target.config["main_board"], vals[2])
         self.assertEqual(len(target.config["destination_lists"]), 2)
         self.assertEqual(len(target.config["destination_lists"]["Label One"]), 2)
         self.assertEqual(len(target.config["destination_lists"]["Label Three"]), 1)
@@ -519,7 +519,7 @@ class TestLoadConfig(unittest.TestCase):
         self.assertEqual(target.config["name"], "Sample configuration")
         self.assertEqual(target.config["key"], "abc")
         self.assertEqual(target.config["token"], "def")
-        self.assertEqual(target.config["master_board"], "ghi")
+        self.assertEqual(target.config["main_board"], "ghi")
         self.assertEqual(len(target.config["destination_lists"]), 3)
         self.assertEqual(len(target.config["destination_lists"]["Label One"]), 1)
         self.assertEqual(target.config["destination_lists"]["Label One"][0], "a1a1a1a1a1a1a1a1a1a1a1a1")

--- a/tests/test_process_master_card.py
+++ b/tests/test_process_master_card.py
@@ -17,25 +17,25 @@ sys.path.append('.')
 target = __import__("syncboom")
 
 
-class TestProcessMasterCard(unittest.TestCase):
-    def test_process_master_card_0(self):
+class TestProcessMainCard(unittest.TestCase):
+    def test_process_main_card_0(self):
         """
-        Test processing a new master card without labels or attachments
+        Test processing a new main card without labels or attachments
         """
         target.config = {"key": "ghi", "token": "jkl", "destination_lists": []}
-        master_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
+        main_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
             "labels": [], "badges": {"attachments": 0}}
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (0, 0, 0))
         self.assertEqual(cm.output, ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 0 destination lists',
-            'INFO:root:This master card has no slave cards'])
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 0 destination lists',
+            'INFO:root:This main card has no subordinate cards'])
 
-    def test_process_master_card_unknown_label(self):
+    def test_process_main_card_unknown_label(self):
         """
-        Test processing a new master card with one label that is not in the config
+        Test processing a new main card with one label that is not in the config
         """
         target.config = {"key": "ghi", "token": "jkl",
             "destination_lists": {
@@ -46,20 +46,20 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
+        main_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
             "labels": [{"name": "Unknown label"}], "badges": {"attachments": 0}}
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (0, 0, 0))
         self.assertEqual(cm.output, ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 0 destination lists',
-            'INFO:root:This master card has no slave cards'])
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 0 destination lists',
+            'INFO:root:This main card has no subordinate cards'])
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_one_label(self, t_pr):
+    def test_process_main_card_one_label(self, t_pr):
         """
-        Test processing a new master card with one recognized label
+        Test processing a new main card with one recognized label
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": True})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -71,11 +71,11 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
-        t_pr.side_effect = [{"id": "b"*24, "name": "Slave card One",
+        t_pr.side_effect = [{"id": "b"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "l"*24,
                 "url": "https://trello.com/c/abcd1234/blablabla2"},
             {"name": "Board name"},
@@ -84,25 +84,25 @@ class TestProcessMasterCard(unittest.TestCase):
             {},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 1))
         expected = ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 1 destination lists',
-            'DEBUG:root:Creating new slave card',
-            'DEBUG:root:New slave card ID: bbbbbbbbbbbbbbbbbbbbbbbb',
-            "DEBUG:root:New master card metadata: \n- 'Slave card One' on list '**Board name|List name**'",
-            'INFO:root:This master card has 1 slave cards (1 newly created)',
-            'DEBUG:root:Updating master card metadata',
-            "DEBUG:root:abc\n\n--------------------------------\n*== DO NOT EDIT BELOW THIS LINE ==*\n\n- 'Slave card One' on list '**Board name|List name**'",
-            'DEBUG:root:Attaching master card tttttttttttttttttttttttt to slave card bbbbbbbbbbbbbbbbbbbbbbbb',
-            'DEBUG:root:Attaching slave card bbbbbbbbbbbbbbbbbbbbbbbb to master card tttttttttttttttttttttttt']
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 1 destination lists',
+            'DEBUG:root:Creating new subordinate card',
+            'DEBUG:root:New subordinate card ID: bbbbbbbbbbbbbbbbbbbbbbbb',
+            "DEBUG:root:New main card metadata: \n- 'Subordinate card One' on list '**Board name|List name**'",
+            'INFO:root:This main card has 1 subordinate cards (1 newly created)',
+            'DEBUG:root:Updating main card metadata',
+            "DEBUG:root:abc\n\n--------------------------------\n*== DO NOT EDIT BELOW THIS LINE ==*\n\n- 'Subordinate card One' on list '**Board name|List name**'",
+            'DEBUG:root:Attaching main card tttttttttttttttttttttttt to subordinate card bbbbbbbbbbbbbbbbbbbbbbbb',
+            'DEBUG:root:Attaching subordinate card bbbbbbbbbbbbbbbbbbbbbbbb to main card tttttttttttttttttttttttt']
         self.assertEqual(cm.output, expected)
         target.args = None
 
-    def test_process_master_card_label_multiple(self):
+    def test_process_main_card_label_multiple(self):
         """
-        Test processing a new master card with one label that maps to multiple lists
+        Test processing a new main card with one label that maps to multiple lists
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": True})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -114,26 +114,26 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
+        main_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
             "labels": [{"name": "All Teams"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb"}
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 2, 2))
         expected = ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 2 destination lists',
-            'DEBUG:root:Creating new slave card',
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 2 destination lists',
+            'DEBUG:root:Creating new subordinate card',
             "DEBUG:root:Skipping POST call to 'https://api.trello.com/1/cards' due to --dry-run parameter",
-            'DEBUG:root:Creating new slave card',
+            'DEBUG:root:Creating new subordinate card',
             "DEBUG:root:Skipping POST call to 'https://api.trello.com/1/cards' due to --dry-run parameter",
-            'INFO:root:This master card has 2 slave cards (2 newly created)']
+            'INFO:root:This main card has 2 subordinate cards (2 newly created)']
         self.assertEqual(cm.output, expected)
         target.args = None
 
-    def test_process_master_card_label_multiple_and_duplicate_single(self):
+    def test_process_main_card_label_multiple_and_duplicate_single(self):
         """
-        Test processing a new master card with one label that maps to multiple lists and another single label that was already in the multiple list
+        Test processing a new main card with one label that maps to multiple lists and another single label that was already in the multiple list
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": True})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -145,27 +145,27 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
+        main_card = {"id": "1a2b3c", "desc": "abc", "name": "Card name",
             "labels": [{"name": "All Teams"}, {"name": "Label One"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb"}
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 2, 2))
         expected = ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 2 destination lists',
-            'DEBUG:root:Creating new slave card',
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 2 destination lists',
+            'DEBUG:root:Creating new subordinate card',
             "DEBUG:root:Skipping POST call to 'https://api.trello.com/1/cards' due to --dry-run parameter",
-            'DEBUG:root:Creating new slave card',
+            'DEBUG:root:Creating new subordinate card',
             "DEBUG:root:Skipping POST call to 'https://api.trello.com/1/cards' due to --dry-run parameter",
-            'INFO:root:This master card has 2 slave cards (2 newly created)']
+            'INFO:root:This main card has 2 subordinate cards (2 newly created)']
         self.assertEqual(cm.output, expected)
         target.args = None
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_dummy_attachment(self, t_pr):
+    def test_process_main_card_dummy_attachment(self, t_pr):
         """
-        Test processing a new master card with one non-Trello attachment
+        Test processing a new main card with one non-Trello attachment
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": True})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -177,12 +177,12 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 1},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
         t_pr.side_effect = [[{"id": "rrr", "url": "https://monip.org"}],
-            {"id": "b"*24, "name": "Slave card One",
+            {"id": "b"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "l"*24,
                 "url": "https://trello.com/c/abcd1234/blablabla2"},
             {"name": "Board name"},
@@ -191,27 +191,27 @@ class TestProcessMasterCard(unittest.TestCase):
             {},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 1))
         expected = ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 1 destination lists',
-            'DEBUG:root:Getting 1 attachments on master card tttttttttttttttttttttttt',
-            'DEBUG:root:Creating new slave card',
-            'DEBUG:root:New slave card ID: bbbbbbbbbbbbbbbbbbbbbbbb',
-            "DEBUG:root:New master card metadata: \n- 'Slave card One' on list '**Board name|List name**'",
-            'INFO:root:This master card has 1 slave cards (1 newly created)',
-            'DEBUG:root:Updating master card metadata',
-            "DEBUG:root:abc\n\n--------------------------------\n*== DO NOT EDIT BELOW THIS LINE ==*\n\n- 'Slave card One' on list '**Board name|List name**'",
-            'DEBUG:root:Attaching master card tttttttttttttttttttttttt to slave card bbbbbbbbbbbbbbbbbbbbbbbb',
-            'DEBUG:root:Attaching slave card bbbbbbbbbbbbbbbbbbbbbbbb to master card tttttttttttttttttttttttt']
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 1 destination lists',
+            'DEBUG:root:Getting 1 attachments on main card tttttttttttttttttttttttt',
+            'DEBUG:root:Creating new subordinate card',
+            'DEBUG:root:New subordinate card ID: bbbbbbbbbbbbbbbbbbbbbbbb',
+            "DEBUG:root:New main card metadata: \n- 'Subordinate card One' on list '**Board name|List name**'",
+            'INFO:root:This main card has 1 subordinate cards (1 newly created)',
+            'DEBUG:root:Updating main card metadata',
+            "DEBUG:root:abc\n\n--------------------------------\n*== DO NOT EDIT BELOW THIS LINE ==*\n\n- 'Subordinate card One' on list '**Board name|List name**'",
+            'DEBUG:root:Attaching main card tttttttttttttttttttttttt to subordinate card bbbbbbbbbbbbbbbbbbbbbbbb',
+            'DEBUG:root:Attaching subordinate card bbbbbbbbbbbbbbbbbbbbbbbb to main card tttttttttttttttttttttttt']
         self.assertEqual(cm.output, expected)
         target.args = None
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_attachment(self, t_pr):
+    def test_process_main_card_attachment(self, t_pr):
         """
-        Test processing a new master card with one Trello attachment
+        Test processing a new main card with one Trello attachment
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": True})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -223,36 +223,36 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 1},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
         t_pr.side_effect = [[{"id": "rrr", "url": "https://trello.com/c/abcd1234/blablabla4"}],
-            {"id": "q"*24, "name": "Slave card One",
+            {"id": "q"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "aaa"},
             {"name": "Board name"},
             {"name": "List name"},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 0))
         expected = ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 1 destination lists',
-            'DEBUG:root:Getting 1 attachments on master card tttttttttttttttttttttttt',
-            "DEBUG:root:Slave card qqqqqqqqqqqqqqqqqqqqqqqq already exists on list aaa",
-            "DEBUG:root:{'id': 'qqqqqqqqqqqqqqqqqqqqqqqq', 'name': 'Slave card One', 'idBoard': 'kkkkkkkkkkkkkkkkkkkkkkkk', 'idList': 'aaa'}",
-            "DEBUG:root:New master card metadata: \n- 'Slave card One' on list '**Board name|List name**'",
-            'INFO:root:This master card has 1 slave cards (0 newly created)',
-            'DEBUG:root:Updating master card metadata',
-            "DEBUG:root:abc\n\n--------------------------------\n*== DO NOT EDIT BELOW THIS LINE ==*\n\n- 'Slave card One' on list '**Board name|List name**'"]
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 1 destination lists',
+            'DEBUG:root:Getting 1 attachments on main card tttttttttttttttttttttttt',
+            "DEBUG:root:Subordinate card qqqqqqqqqqqqqqqqqqqqqqqq already exists on list aaa",
+            "DEBUG:root:{'id': 'qqqqqqqqqqqqqqqqqqqqqqqq', 'name': 'Subordinate card One', 'idBoard': 'kkkkkkkkkkkkkkkkkkkkkkkk', 'idList': 'aaa'}",
+            "DEBUG:root:New main card metadata: \n- 'Subordinate card One' on list '**Board name|List name**'",
+            'INFO:root:This main card has 1 subordinate cards (0 newly created)',
+            'DEBUG:root:Updating main card metadata',
+            "DEBUG:root:abc\n\n--------------------------------\n*== DO NOT EDIT BELOW THIS LINE ==*\n\n- 'Subordinate card One' on list '**Board name|List name**'"]
         self.assertEqual(cm.output, expected)
         target.args = None
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_attachment_no_label(self, t_pr):
+    def test_process_main_card_attachment_no_label(self, t_pr):
         """
-        Test processing a new master card with one Trello attachment but no label
+        Test processing a new main card with one Trello attachment but no label
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": True})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -264,32 +264,32 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [], "badges": {"attachments": 1},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
         t_pr.side_effect = [[{"id": "rrr", "url": "https://trello.com/c/abcd1234/blablabla4"}],
-            {"id": "q"*24, "name": "Slave card One",
+            {"id": "q"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "aaa"},
             {"name": "Board name"},
             {"name": "List name"},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (0, 0, 0))
         expected = ['DEBUG:root:================================================================',
-            "DEBUG:root:Process master card 'Card name'",
-            'DEBUG:root:Master card is to be synced on 0 destination lists',
-            'DEBUG:root:Getting 1 attachments on master card tttttttttttttttttttttttt',
-            "DEBUG:root:Master card has been unlinked from slave cards",
-            "INFO:root:This master card has no slave cards"]
+            "DEBUG:root:Process main card 'Card name'",
+            'DEBUG:root:Main card is to be synced on 0 destination lists',
+            'DEBUG:root:Getting 1 attachments on main card tttttttttttttttttttttttt',
+            "DEBUG:root:Main card has been unlinked from subordinate cards",
+            "INFO:root:This main card has no subordinate cards"]
         self.assertEqual(cm.output, expected)
         target.args = None
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_one_label_wet_run_no_checklist(self, t_pr):
+    def test_process_main_card_one_label_wet_run_no_checklist(self, t_pr):
         """
-        Test processing a new master card with one recognized label, no dry_run, without a checklist
+        Test processing a new main card with one recognized label, no dry_run, without a checklist
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": False})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -304,11 +304,11 @@ class TestProcessMasterCard(unittest.TestCase):
             "friendly_names": {
                 "Label Two": "Nicer Label"
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
-        t_pr.side_effect = [{"id": "b"*24, "name": "Slave card One",
+        t_pr.side_effect = [{"id": "b"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "l"*24,
                 "url": "https://trello.com/c/abcd1234/blablabla2"},
             {"name": "Board name"},
@@ -322,7 +322,7 @@ class TestProcessMasterCard(unittest.TestCase):
             {},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 1))
         expected = "\n".join(["DEBUG:root:Retrieving checklists from card tttttttttttttttttttttttt",
             "DEBUG:root:Creating new checklist",
@@ -333,9 +333,9 @@ class TestProcessMasterCard(unittest.TestCase):
         target.args = None
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_one_label_wet_run_unrelated_checklist(self, t_pr):
+    def test_process_main_card_one_label_wet_run_unrelated_checklist(self, t_pr):
         """
-        Test processing a new master card with one recognized label, no dry_run, with one unrelated checklist
+        Test processing a new main card with one recognized label, no dry_run, with one unrelated checklist
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": False})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -350,11 +350,11 @@ class TestProcessMasterCard(unittest.TestCase):
             "friendly_names": {
                 "Label Two": "Nicer Label"
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
-        t_pr.side_effect = [{"id": "b"*24, "name": "Slave card One",
+        t_pr.side_effect = [{"id": "b"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "l"*24,
                 "url": "https://trello.com/c/abcd1234/blablabla2"},
             {"name": "Board name"},
@@ -368,10 +368,10 @@ class TestProcessMasterCard(unittest.TestCase):
             {},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 1))
         expected = "\n".join(["DEBUG:root:Retrieving checklists from card tttttttttttttttttttttttt",
-            "DEBUG:root:Already 1 checklists on this master card: Unrelated checklist",
+            "DEBUG:root:Already 1 checklists on this main card: Unrelated checklist",
             "DEBUG:root:Creating new checklist",
             "DEBUG:root:{'id': 'wwwwwwwwwwwwwwwwwwwwwwww', 'name': 'New checklist'}",
             "DEBUG:root:Adding new checklistitem 'Destination board name' to checklist wwwwwwwwwwwwwwwwwwwwwwww",
@@ -381,9 +381,9 @@ class TestProcessMasterCard(unittest.TestCase):
 
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_one_label_wet_run_friendly_name_checklist(self, t_pr):
+    def test_process_main_card_one_label_wet_run_friendly_name_checklist(self, t_pr):
         """
-        Test processing a new master card with one recognized label, no dry_run,
+        Test processing a new main card with one recognized label, no dry_run,
         without a checklist and using a friendly name as checklist item instead of the board's name
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": False})()
@@ -399,11 +399,11 @@ class TestProcessMasterCard(unittest.TestCase):
             "friendly_names": {
                 "Destination board name": "Nicer Label"
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
-        t_pr.side_effect = [{"id": "b"*24, "name": "Slave card One",
+        t_pr.side_effect = [{"id": "b"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "l"*24,
                 "url": "https://trello.com/c/abcd1234/blablabla2"},
             {"name": "Board name"},
@@ -417,7 +417,7 @@ class TestProcessMasterCard(unittest.TestCase):
             {},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 1))
         expected = "\n".join(["DEBUG:root:Retrieving checklists from card tttttttttttttttttttttttt",
             "DEBUG:root:Creating new checklist",
@@ -428,9 +428,9 @@ class TestProcessMasterCard(unittest.TestCase):
         target.args = None
 
     @patch("syncboom.perform_request")
-    def test_process_master_card_one_label_wet_run_related_checklist(self, t_pr):
+    def test_process_main_card_one_label_wet_run_related_checklist(self, t_pr):
         """
-        Test processing a new master card with one recognized label, no dry_run, with already the related checklist
+        Test processing a new main card with one recognized label, no dry_run, with already the related checklist
         """
         target.args = type(inspect.stack()[0][3], (object,), {"dry_run": False})()
         target.config = {"key": "ghi", "token": "jkl",
@@ -442,11 +442,11 @@ class TestProcessMasterCard(unittest.TestCase):
                   "ddd"
                 ]
             }}
-        master_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
+        main_card = {"id": "t"*24, "desc": "abc", "name": "Card name",
             "labels": [{"name": "Label One"}], "badges": {"attachments": 0},
             "shortUrl": "https://trello.com/c/eoK0Rngb",
             "url": "https://trello.com/c/eoK0Rngb/blablabla"}
-        t_pr.side_effect = [{"id": "b"*24, "name": "Slave card One",
+        t_pr.side_effect = [{"id": "b"*24, "name": "Subordinate card One",
                 "idBoard": "k"*24, "idList": "l"*24,
                 "url": "https://trello.com/c/abcd1234/blablabla2"},
             {"name": "Board name"},
@@ -456,10 +456,10 @@ class TestProcessMasterCard(unittest.TestCase):
             {},
             {}]
         with self.assertLogs(level='DEBUG') as cm:
-            output = target.process_master_card(master_card)
+            output = target.process_main_card(main_card)
         self.assertEqual(output, (1, 1, 1))
         expected = "\n".join(["DEBUG:root:Retrieving checklists from card tttttttttttttttttttttttt",
-            "DEBUG:root:Already 1 checklists on this master card: Involved Teams"])
+            "DEBUG:root:Already 1 checklists on this main card: Involved Teams"])
         self.assertTrue(expected in "\n".join(cm.output))
         target.args = None
         target.config


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.